### PR TITLE
api: accept raw objects as input

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "repository": "joakimbeng/unistyle",
   "license": "MIT",
   "devDependencies": {
-    "ava": "^0.1.0",
+    "ava": "^0.2.0",
     "xo": "^0.8.0"
   },
   "xo": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,16 @@ var pixelify = require('pixelify');
 
 module.exports = function compile(opts, cb) {
   opts = opts || {};
+  var src = opts.src;
   var file = opts.file;
   var output = opts.output;
-  var mod = arrify(require(resolve(file)));
+  var mod;
+
+  if (file) {
+    mod = arrify(require(resolve(file)));
+  } else {
+    mod = arrify(src);
+  }
 
   var css = absurd(function (api) {
     mod.forEach(function (decl) {

--- a/test/unistyle-test.js
+++ b/test/unistyle-test.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec;
 var readFileSync = require('fs').readFileSync;
+var compile = require('../src');
 var join = require('path').join;
 var test = require('ava');
 
@@ -10,5 +11,14 @@ test('compiles esnext code to css', function (assert) {
     var actual = css.toString().trim();
     var expected = readFileSync(join(__dirname, 'expected.css'), 'utf8').trim();
     assert.is(actual, expected, 'The correct css should have been compiled');
+  });
+});
+
+test('accepts raw objects as input', function (assert) {
+  assert.plan(2);
+  var src = {body: {padding: '10px'}};
+  compile({src: src}, function (err, css) {
+    assert.error(err, 'No error should occur');
+    assert.ok(css);
   });
 });


### PR DESCRIPTION
- now supports `#compile({src: { ... })` instead of just a file
- also bumped ava for additional assertion methods (like `.ok()`, `.true`, ...)
